### PR TITLE
fix: add /api prefix to routes

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -146,8 +146,8 @@ kubectl logs -l app=tutuplapak -f
 
 ### Health Checks
 
-- **Liveness**: `GET /v1/health`
-- **Readiness**: `GET /v1/health/ready`
+- **Liveness**: `GET /api/v1/health`
+- **Readiness**: `GET /api/v1/health/ready`
 - **Metrics**: `GET /metrics` (Prometheus format)
 
 ### Prometheus Metrics

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -10,7 +10,7 @@ import (
 // SetupRoutes configures all the routes for the application
 func SetupRoutes(router *gin.Engine, healthHandler *handlers.HealthHandler, userHandler *handlers.UserHandler, registerHandler *handlers.RegisterHandler, loginHandler *handlers.LoginHandler, fileHandler *handlers.FileHandler) {
 	// API version 1
-	v1 := router.Group("/v1")
+	v1 := router.Group("/api/v1")
 	{
 		// Login & register routes
 		v1.POST("/login", loginHandler.Login)


### PR DESCRIPTION
What's inside:
- Add /api prefix to `routes.go`
- Change `DEPLOYMENT.md` to use new API route